### PR TITLE
feat(ui): add user taste similarity dashboard

### DIFF
--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/user-taste-similarity/page.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/user-taste-similarity/page.tsx
@@ -1,0 +1,254 @@
+import { Sparkles } from "lucide-react";
+import { redirect } from "next/navigation";
+import { Container } from "@/components/Container";
+import { FormattedDate } from "@/components/FormattedDate";
+import { PageTitle } from "@/components/PageTitle";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { getServer } from "@/lib/db/server";
+import { getUserTasteSimilarity } from "@/lib/db/user-taste-similarity";
+import { isUserAdmin } from "@/lib/db/users";
+import type {
+  UserTasteSimilarityCell,
+  UserTasteSimilarityPair,
+} from "@/lib/user-taste-similarity";
+
+function formatSimilarity(similarity: number | null): string {
+  if (similarity === null) {
+    return "N/A";
+  }
+
+  return `${Math.round(similarity * 100)}%`;
+}
+
+function getSimilarityBadgeVariant(
+  similarity: number,
+): "default" | "secondary" {
+  return similarity >= 0.8 ? "default" : "secondary";
+}
+
+function SimilarityCell({ cell }: { cell: UserTasteSimilarityCell }) {
+  const opacity = cell.similarity === null ? 0 : 0.12 + cell.similarity * 0.72;
+
+  return (
+    <div className="relative flex h-14 min-w-16 items-center justify-center overflow-hidden rounded-md bg-muted">
+      <div
+        className="absolute inset-0 bg-primary"
+        style={{ opacity }}
+        aria-hidden="true"
+      />
+      <span className="relative text-xs font-medium">
+        {formatSimilarity(cell.similarity)}
+      </span>
+    </div>
+  );
+}
+
+function TopPairRow({
+  pair,
+  rank,
+}: {
+  pair: UserTasteSimilarityPair;
+  rank: number;
+}) {
+  return (
+    <div className="grid grid-cols-[2rem_minmax(0,1fr)_auto] items-center gap-3 rounded-md border px-3 py-2">
+      <span className="text-sm text-muted-foreground">{rank}</span>
+      <div className="min-w-0">
+        <p className="truncate text-sm font-medium">
+          {pair.leftUserName} + {pair.rightUserName}
+        </p>
+      </div>
+      <Badge variant={getSimilarityBadgeVariant(pair.similarity)}>
+        {formatSimilarity(pair.similarity)}
+      </Badge>
+    </div>
+  );
+}
+
+export default async function UserTasteSimilarityPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const [server, isAdmin] = await Promise.all([
+    getServer({ serverId: id }),
+    isUserAdmin(),
+  ]);
+
+  if (!server) {
+    redirect("/not-found");
+  }
+
+  if (!isAdmin) {
+    redirect(`/servers/${id}/dashboard`);
+  }
+
+  const data = await getUserTasteSimilarity({ serverId: server.id });
+  const topPairs = data.pairs.slice(0, 10);
+  const strongestPair = data.pairs[0];
+
+  return (
+    <Container>
+      <PageTitle
+        title="User Taste Similarity"
+        subtitle="Admin-only comparison of user taste embeddings."
+      />
+
+      {data.users.length < 2 ? (
+        <Alert>
+          <Sparkles />
+          <AlertTitle>Not enough user taste profiles</AlertTitle>
+          <AlertDescription>
+            Generate user embeddings for at least two users before comparing
+            taste similarity.
+          </AlertDescription>
+        </Alert>
+      ) : (
+        <div className="flex flex-col gap-6">
+          <div className="grid gap-4 md:grid-cols-3">
+            <Card>
+              <CardHeader>
+                <CardTitle>Profiles</CardTitle>
+                <CardDescription>Users with taste embeddings</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-3xl font-bold">{data.users.length}</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Compared Pairs</CardTitle>
+                <CardDescription>Unique user combinations</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-3xl font-bold">{data.pairs.length}</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Closest Match</CardTitle>
+                <CardDescription>
+                  Highest taste similarity in this server
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                {strongestPair ? (
+                  <div className="flex flex-col gap-1">
+                    <p className="truncate text-sm font-medium">
+                      {strongestPair.leftUserName} +{" "}
+                      {strongestPair.rightUserName}
+                    </p>
+                    <p className="text-3xl font-bold">
+                      {formatSimilarity(strongestPair.similarity)}
+                    </p>
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground">N/A</p>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_22rem]">
+            <Card className="min-w-0">
+              <CardHeader>
+                <CardTitle>Taste Matrix</CardTitle>
+                <CardDescription>
+                  Darker cells mean stronger similarity between two users.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="overflow-auto rounded-md border">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="sticky left-0 z-10 min-w-40 bg-card">
+                          User
+                        </TableHead>
+                        {data.users.map((user) => (
+                          <TableHead
+                            key={user.userId}
+                            className="min-w-20 text-center"
+                          >
+                            <span className="block truncate">
+                              {user.userName}
+                            </span>
+                          </TableHead>
+                        ))}
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {data.matrix.map((row) => (
+                        <TableRow key={row.userId}>
+                          <TableCell className="sticky left-0 z-10 min-w-40 bg-card">
+                            <div className="flex flex-col gap-1">
+                              <span className="font-medium">
+                                {row.userName}
+                              </span>
+                              <span className="text-xs text-muted-foreground">
+                                {row.itemCount} items, updated{" "}
+                                <FormattedDate
+                                  date={row.lastCalculatedAt}
+                                  format="date"
+                                />
+                              </span>
+                            </div>
+                          </TableCell>
+                          {row.cells.map((cell) => (
+                            <TableCell
+                              key={cell.userId}
+                              className="p-2 text-center"
+                            >
+                              <SimilarityCell cell={cell} />
+                            </TableCell>
+                          ))}
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Closest Pairs</CardTitle>
+                <CardDescription>
+                  Top taste matches by cosine similarity
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex flex-col gap-2">
+                  {topPairs.map((pair, index) => (
+                    <TopPairRow
+                      key={`${pair.leftUserId}-${pair.rightUserId}`}
+                      pair={pair}
+                      rank={index + 1}
+                    />
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      )}
+    </Container>
+  );
+}

--- a/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/user-taste-similarity/page.tsx
+++ b/apps/nextjs-app/app/(app)/servers/[id]/(auth)/dashboard/user-taste-similarity/page.tsx
@@ -27,6 +27,7 @@ import type {
   UserTasteSimilarityCell,
   UserTasteSimilarityPair,
 } from "@/lib/user-taste-similarity";
+import { cn } from "@/lib/utils";
 
 function formatSimilarity(similarity: number | null): string {
   if (similarity === null) {
@@ -36,25 +37,61 @@ function formatSimilarity(similarity: number | null): string {
   return `${Math.round(similarity * 100)}%`;
 }
 
-function getSimilarityBadgeVariant(
-  similarity: number,
-): "default" | "secondary" {
-  return similarity >= 0.8 ? "default" : "secondary";
+function getSimilarityCellTone(similarity: number | null): {
+  className: string;
+} {
+  if (similarity === null) {
+    return {
+      className: "bg-muted text-muted-foreground",
+    };
+  }
+
+  if (similarity === 1) {
+    return {
+      className: "border-red-700 bg-red-700 text-white",
+    };
+  }
+
+  if (similarity >= 0.9) {
+    return {
+      className: "border-purple-700 bg-purple-700 text-white",
+    };
+  }
+
+  if (similarity >= 0.8) {
+    return {
+      className: "border-emerald-700 bg-emerald-700 text-white",
+    };
+  }
+
+  if (similarity >= 0.6) {
+    return {
+      className: "border-blue-700 bg-blue-700 text-white",
+    };
+  }
+
+  if (similarity < 0.2) {
+    return {
+      className: "border-zinc-800 bg-zinc-800 text-white",
+    };
+  }
+
+  return {
+    className: "border-amber-700 bg-amber-700 text-white",
+  };
 }
 
 function SimilarityCell({ cell }: { cell: UserTasteSimilarityCell }) {
-  const opacity = cell.similarity === null ? 0 : 0.12 + cell.similarity * 0.72;
+  const tone = getSimilarityCellTone(cell.similarity);
 
   return (
-    <div className="relative flex h-14 min-w-16 items-center justify-center overflow-hidden rounded-md bg-muted">
-      <div
-        className="absolute inset-0 bg-primary"
-        style={{ opacity }}
-        aria-hidden="true"
-      />
-      <span className="relative text-xs font-medium">
-        {formatSimilarity(cell.similarity)}
-      </span>
+    <div
+      className={cn(
+        "flex h-14 min-w-16 items-center justify-center rounded-md border text-xs font-semibold",
+        tone.className,
+      )}
+    >
+      {formatSimilarity(cell.similarity)}
     </div>
   );
 }
@@ -74,7 +111,13 @@ function TopPairRow({
           {pair.leftUserName} + {pair.rightUserName}
         </p>
       </div>
-      <Badge variant={getSimilarityBadgeVariant(pair.similarity)}>
+      <Badge
+        variant="outline"
+        className={cn(
+          "border text-white",
+          getSimilarityCellTone(pair.similarity).className,
+        )}
+      >
         {formatSimilarity(pair.similarity)}
       </Badge>
     </div>

--- a/apps/nextjs-app/components/SideBar.tsx
+++ b/apps/nextjs-app/components/SideBar.tsx
@@ -15,6 +15,7 @@ import {
   type LucideIcon,
   MessageSquare,
   Monitor,
+  Network,
   RefreshCw,
   Settings,
   Shield,
@@ -112,6 +113,11 @@ const admin_items = [
     title: "Users",
     url: "/users",
     icon: Users,
+  },
+  {
+    title: "Taste Similarity",
+    url: "/dashboard/user-taste-similarity",
+    icon: Network,
   },
 ];
 

--- a/apps/nextjs-app/lib/db/user-taste-similarity.ts
+++ b/apps/nextjs-app/lib/db/user-taste-similarity.ts
@@ -1,0 +1,41 @@
+"use server";
+
+import "server-only";
+
+import { db } from "@streamystats/database";
+import {
+  userEmbeddings,
+  users as usersTable,
+} from "@streamystats/database/schema";
+import { and, asc, eq } from "drizzle-orm";
+import {
+  buildUserTasteSimilarity,
+  type UserTasteSimilarityResult,
+} from "@/lib/user-taste-similarity";
+
+export async function getUserTasteSimilarity({
+  serverId,
+}: {
+  serverId: number;
+}): Promise<UserTasteSimilarityResult> {
+  const rows = await db
+    .select({
+      userId: usersTable.id,
+      userName: usersTable.name,
+      embedding: userEmbeddings.embedding,
+      itemCount: userEmbeddings.itemCount,
+      lastCalculatedAt: userEmbeddings.lastCalculatedAt,
+    })
+    .from(userEmbeddings)
+    .innerJoin(
+      usersTable,
+      and(
+        eq(usersTable.id, userEmbeddings.userId),
+        eq(usersTable.serverId, userEmbeddings.serverId),
+      ),
+    )
+    .where(eq(userEmbeddings.serverId, serverId))
+    .orderBy(asc(usersTable.name));
+
+  return buildUserTasteSimilarity(rows);
+}

--- a/apps/nextjs-app/lib/user-taste-similarity.ts
+++ b/apps/nextjs-app/lib/user-taste-similarity.ts
@@ -74,13 +74,26 @@ export function buildUserTasteSimilarity(
   users: UserTasteEmbeddingInput[],
 ): UserTasteSimilarityResult {
   const pairs: UserTasteSimilarityPair[] = [];
+  const matrix: UserTasteSimilarityRow[] = [];
 
-  const matrix = users.map((leftUser, leftIndex) => {
-    const cells = users.map((rightUser, rightIndex) => {
-      const similarity =
-        leftIndex === rightIndex
-          ? 1
-          : calculateCosineSimilarity(leftUser.embedding, rightUser.embedding);
+  for (let leftIndex = 0; leftIndex < users.length; leftIndex++) {
+    const leftUser = users[leftIndex];
+    const cells: UserTasteSimilarityCell[] = [];
+
+    for (let rightIndex = 0; rightIndex < users.length; rightIndex++) {
+      const rightUser = users[rightIndex];
+      let similarity: number | null;
+
+      if (leftIndex === rightIndex) {
+        similarity = 1;
+      } else if (leftIndex > rightIndex) {
+        similarity = matrix[rightIndex]?.cells[leftIndex]?.similarity ?? null;
+      } else {
+        similarity = calculateCosineSimilarity(
+          leftUser.embedding,
+          rightUser.embedding,
+        );
+      }
 
       if (rightIndex > leftIndex && similarity !== null) {
         pairs.push({
@@ -92,21 +105,21 @@ export function buildUserTasteSimilarity(
         });
       }
 
-      return {
+      cells.push({
         userId: rightUser.userId,
         userName: rightUser.userName,
         similarity,
-      };
-    });
+      });
+    }
 
-    return {
+    matrix.push({
       userId: leftUser.userId,
       userName: leftUser.userName,
       itemCount: leftUser.itemCount,
       lastCalculatedAt: leftUser.lastCalculatedAt,
       cells,
-    };
-  });
+    });
+  }
 
   pairs.sort((leftPair, rightPair) => {
     if (rightPair.similarity !== leftPair.similarity) {

--- a/apps/nextjs-app/lib/user-taste-similarity.ts
+++ b/apps/nextjs-app/lib/user-taste-similarity.ts
@@ -1,0 +1,126 @@
+export interface UserTasteEmbeddingInput {
+  userId: string;
+  userName: string;
+  embedding: number[];
+  itemCount: number;
+  lastCalculatedAt: Date;
+}
+
+export interface UserTasteSimilarityCell {
+  userId: string;
+  userName: string;
+  similarity: number | null;
+}
+
+export interface UserTasteSimilarityRow {
+  userId: string;
+  userName: string;
+  itemCount: number;
+  lastCalculatedAt: Date;
+  cells: UserTasteSimilarityCell[];
+}
+
+export interface UserTasteSimilarityPair {
+  leftUserId: string;
+  leftUserName: string;
+  rightUserId: string;
+  rightUserName: string;
+  similarity: number;
+}
+
+export interface UserTasteSimilarityResult {
+  users: UserTasteEmbeddingInput[];
+  matrix: UserTasteSimilarityRow[];
+  pairs: UserTasteSimilarityPair[];
+}
+
+export function calculateCosineSimilarity(
+  left: number[],
+  right: number[],
+): number | null {
+  if (left.length === 0 || left.length !== right.length) {
+    return null;
+  }
+
+  let dotProduct = 0;
+  let leftNorm = 0;
+  let rightNorm = 0;
+
+  for (let index = 0; index < left.length; index++) {
+    const leftValue = left[index];
+    const rightValue = right[index];
+    dotProduct += leftValue * rightValue;
+    leftNorm += leftValue * leftValue;
+    rightNorm += rightValue * rightValue;
+  }
+
+  if (leftNorm === 0 || rightNorm === 0) {
+    return null;
+  }
+
+  const rawSimilarity =
+    dotProduct / (Math.sqrt(leftNorm) * Math.sqrt(rightNorm));
+  if (Math.abs(rawSimilarity - 1) < 1e-12) {
+    return 1;
+  }
+  if (Math.abs(rawSimilarity) < 1e-12) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(1, rawSimilarity));
+}
+
+export function buildUserTasteSimilarity(
+  users: UserTasteEmbeddingInput[],
+): UserTasteSimilarityResult {
+  const pairs: UserTasteSimilarityPair[] = [];
+
+  const matrix = users.map((leftUser, leftIndex) => {
+    const cells = users.map((rightUser, rightIndex) => {
+      const similarity =
+        leftIndex === rightIndex
+          ? 1
+          : calculateCosineSimilarity(leftUser.embedding, rightUser.embedding);
+
+      if (rightIndex > leftIndex && similarity !== null) {
+        pairs.push({
+          leftUserId: leftUser.userId,
+          leftUserName: leftUser.userName,
+          rightUserId: rightUser.userId,
+          rightUserName: rightUser.userName,
+          similarity,
+        });
+      }
+
+      return {
+        userId: rightUser.userId,
+        userName: rightUser.userName,
+        similarity,
+      };
+    });
+
+    return {
+      userId: leftUser.userId,
+      userName: leftUser.userName,
+      itemCount: leftUser.itemCount,
+      lastCalculatedAt: leftUser.lastCalculatedAt,
+      cells,
+    };
+  });
+
+  pairs.sort((leftPair, rightPair) => {
+    if (rightPair.similarity !== leftPair.similarity) {
+      return rightPair.similarity - leftPair.similarity;
+    }
+
+    const leftNames = `${leftPair.leftUserName} ${leftPair.rightUserName}`;
+    const rightNames = `${rightPair.leftUserName} ${rightPair.rightUserName}`;
+    return leftNames.localeCompare(rightNames);
+  });
+
+  return {
+    users,
+    matrix,
+    pairs,
+  };
+}


### PR DESCRIPTION
Implement a new admin-only dashboard to compare user taste similarity using cosine similarity of user embeddings.

- Add `UserTasteSimilarityPage` to visualize similarity matrix and top pairs.
- Implement `calculateCosineSimilarity` and `buildUserTasteSimilarity` utilities for embedding comparison.
- Add server action `getUserTasteSimilarity` to fetch user embeddings from the database.
- Update `SideBar` to include the new Taste Similarity navigation item.